### PR TITLE
PoC: use miqt instead of DOtherSide

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,2 @@
+path="/home/arnetheduck/src/miqt/qt"
+path="/home/arnetheduck/src/miqt/qt/network"

--- a/src/nimqml.nim
+++ b/src/nimqml.nim
@@ -11,8 +11,7 @@ template debugMsg(message: string) =
   echo "NimQml: ", message
 
 template debugMsg(typeName: string, procName: string) =
-  when defined(debug):
-    debugMsg(typeName & ": " & procName)
+  debugMsg(typeName & ": " & procName)
 
 include "nimqml/private/nimqmlmacros.nim"
 include "nimqml/private/dotherside.nim"

--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -1,19 +1,12 @@
-const dynLibName =
-  case system.hostOS:
-    of "windows":
-      "DOtherSide.dll"
-    of "macosx":
-      "libDOtherSide.dylib"
-    else:
-      "libDOtherSide.so.0.(9|8)"
-
+{.push raises: [].}
+import tables
 type
   NimQObject = pointer
   NimQAbstractItemModel = pointer
   NimQAbstractListModel = pointer
   NimQAbstractTableModel = pointer
   DosQMetaObject = distinct pointer
-  DosQObject* = distinct pointer
+  DosQObject = distinct pointer
   DosQObjectWrapper = distinct pointer
   DosQVariant = distinct pointer
   DosQQmlContext = distinct pointer
@@ -82,11 +75,11 @@ type
   DosColumnCountCallback = proc(nimmodel: NimQAbstractItemModel, rawIndex: DosQModelIndex, result: var cint) {.cdecl.}
   DosDataCallback = proc(nimmodel: NimQAbstractItemModel, rawIndex: DosQModelIndex, role: cint, result: DosQVariant) {.cdecl.}
   DosSetDataCallback = proc(nimmodel: NimQAbstractItemModel, rawIndex: DosQModelIndex, value: DosQVariant, role: cint, result: var bool) {.cdecl.}
-  DosRoleNamesCallback = proc(nimmodel: NimQAbstractItemModel, result: DosQHashIntByteArray) {.cdecl.}
+  DosRoleNamesCallback = proc(nimmodel: NimQAbstractItemModel): Table[cint, seq[byte]] {.cdecl.}
   DosFlagsCallback = proc(nimmodel: NimQAbstractItemModel, index: DosQModelIndex, result: var cint) {.cdecl.}
   DosHeaderDataCallback = proc(nimmodel: NimQAbstractItemModel, section: cint, orientation: cint, role: cint, result: DosQVariant) {.cdecl.}
-  DosIndexCallback = proc(nimmodel: NimQAbstractItemModel, row: cint, column: cint, parent: DosQModelIndex, result: DosQModelIndex) {.cdecl.}
-  DosParentCallback = proc(nimmodel: NimQAbstractItemModel, child: DosQModelIndex, result: DosQModelIndex) {.cdecl.}
+  DosIndexCallback = proc(nimmodel: NimQAbstractItemModel, row: cint, column: cint, parent: DosQModelIndex, result: var DosQModelIndex) {.cdecl.}
+  DosParentCallback = proc(nimmodel: NimQAbstractItemModel, child: DosQModelIndex, result: var DosQModelIndex) {.cdecl.}
   DosHasChildrenCallback = proc(nimmodel: NimQAbstractItemModel, parent: DosQModelIndex, result: var bool) {.cdecl.}
   DosCanFetchMoreCallback = proc(nimmodel: NimQAbstractItemModel, parent: DosQModelIndex, result: var bool) {.cdecl.}
   DosFetchMoreCallback = proc(nimmodel: NimQAbstractItemModel, parent: DosQModelIndex) {.cdecl.}
@@ -108,8 +101,11 @@ type
   DosQObjectConnectLambdaCallback = proc(data: pointer, numArguments: cint, arguments: ptr DosQVariantArray) {.cdecl.}
   DosQMetaObjectInvokeMethodCallback = proc(data: pointer) {.cdecl.}
 
+include notherside
+
 # Conversion
-proc resetToNil[T](x: var T) = x = nil.pointer.T
+proc resetToNil[T](x: var T) = reset(x)
+
 proc isNil(x: DosQMetaObject): bool = x.pointer.isNil
 proc isNil(x: DosQVariant): bool = x.pointer.isNil
 proc isNil(x: DosQObject): bool = x.pointer.isNil
@@ -121,185 +117,494 @@ proc isNil(x: DosQModelIndex): bool = x.pointer.isNil
 proc isNil(x: DosQMetaObjectConnection): bool = x.pointer.isNil
 
 # CharArray
-proc dos_chararray_delete(str: cstring) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_chararray_delete(str: cstring) =
+  debugEcho "dos_chararray_delete(str: cstring) "
 
-# QCoreApplication
-proc dos_qcoreapplication_application_dir_path(): cstring {.cdecl, dynlib: dynLibName, importc.}
+# # QCoreApplication
+proc dos_qcoreapplication_application_dir_path(): cstring =
+  debugEcho "dos_qcoreapplication_application_dir_path(): cstring "
 
-# QApplication
-proc dos_qapplication_create() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qapplication_exec() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qapplication_quit() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qapplication_delete() {.cdecl, dynlib: dynLibName, importc.}
+# # QApplication
+var qapp: gen_qapplication.Qapplication
+
+proc dos_qapplication_create() =
+  qapp = gen_qapplication.QApplication.create()
+
+proc dos_qapplication_exec() =
+  discard gen_qapplication.QApplication.exec()
+
+proc dos_qapplication_quit() =
+  gen_qapplication.QApplication.quit()
+
+proc dos_qapplication_delete() =
+  qapp.delete()
 
 # QGuiApplication
-proc dos_qguiapplication_create() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qguiapplication_exec() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qguiapplication_quit() {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qguiapplication_delete() {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qguiapplication_create() =
+  debugEcho "dos_qguiapplication_create() "
+
+proc dos_qguiapplication_exec() =
+  discard gen_qguiapplication.QGuiApplication.exec()
+
+proc dos_qguiapplication_quit() =
+  debugEcho "dos_qguiapplication_quit() "
+
+proc dos_qguiapplication_delete() =
+  debugEcho "dos_qguiapplication_delete() "
 
 # QQmlContext
-proc dos_qqmlcontext_setcontextproperty(context: DosQQmlContext, propertyName: cstring, propertyValue: DosQVariant) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qqmlcontext_setcontextproperty(
+    context: DosQQmlContext, propertyName: cstring, propertyValue: DosQVariant
+) =
+  context.setContextProperty($propertyName, propertyValue)
 
 # QQmlApplicationEngine
-proc dos_qqmlapplicationengine_create(): DosQQmlApplicationEngine {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_load(engine: DosQQmlApplicationEngine, filename: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_load_url(engine: DosQQmlApplicationEngine, url: DosQUrl) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_load_data(engine: DosQQmlApplicationEngine, data: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_add_import_path(engine: DosQQmlApplicationEngine, path: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_context(engine: DosQQmlApplicationEngine): DosQQmlContext {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qqmlapplicationengine_delete(engine: DosQQmlApplicationEngine) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qqmlapplicationengine_create(): DosQQmlApplicationEngine =
+  gen_qqmlapplicationEngine.QQmlApplicationEngine.create()
+
+proc dos_qqmlapplicationengine_load(
+    engine: DosQQmlApplicationEngine, filename: cstring
+) =
+  engine.load($filename)
+
+proc dos_qqmlapplicationengine_load_url(
+    engine: DosQQmlApplicationEngine, url: DosQUrl
+) =
+  engine.load(url)
+
+proc dos_qqmlapplicationengine_load_data(engine: DosQQmlApplicationEngine, data: cstring) = engine.loadData(cast[seq[byte]]($data))
+proc dos_qqmlapplicationengine_add_import_path(engine: DosQQmlApplicationEngine, path: cstring) = engine.addImportPath($path)
+proc dos_qqmlapplicationengine_context(engine: DosQQmlApplicationEngine): DosQQmlContext = engine.rootContext()
+proc dos_qqmlapplicationengine_delete(engine: DosQQmlApplicationEngine) = gen_qqmlapplicationengine.delete(gen_qqmlapplicationengine_types.QQmlApplicationEngine(engine))
 
 # QVariant
-proc dos_qvariant_create(): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_int(value: cint): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_bool(value: bool): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_string(value: cstring): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_qobject(value: DosQObject): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_qvariant(value: DosQVariant): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_float(value: cfloat): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_create_double(value: cdouble): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_delete(variant: DosQVariant) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_isnull(variant: DosQVariant): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_toInt(variant: DosQVariant): cint {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_toBool(variant: DosQVariant): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_toString(variant: DosQVariant): cstring {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_toDouble(variant: DosQVariant): cdouble {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_toFloat(variant: DosQVariant): cfloat {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setInt(variant: DosQVariant, value: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setBool(variant: DosQVariant, value: bool) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setString(variant: DosQVariant, value: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_assign(leftValue: DosQVariant, rightValue: DosQVariant) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setFloat(variant: DosQVariant, value: cfloat) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setDouble(variant: DosQVariant, value: cdouble) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qvariant_setQObject(variant: DosQVariant, value: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qvariant_create(): DosQVariant =
+  gen_qvariant.QVariant.create()
 
-# QObject
-proc dos_qobject_qmetaobject(): DosQMetaObject {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_create(nimobject: NimQObject, metaObject: DosQMetaObject, dosQObjectCallback: DosQObjectCallBack): DosQObject {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_objectName(qobject: DosQObject): cstring {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_setObjectName(qobject: DosQObject, name: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_signal_emit(qobject: DosQObject, signalName: cstring, argumentsCount: cint, arguments: ptr DosQVariantArray)  {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_connect_static(sender: DosQObject, senderFunc: cstring, receiver: DosQObject, receiverFunc: cstring, connectionType: cint): DosQMetaObjectConnection {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_connect_lambda_static(sender: DosQObject, senderFunc: cstring, callback: DosQObjectConnectLambdaCallback, data: pointer, connectionType: cint): DosQMetaObjectConnection {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_connect_lambda_with_context_static(sender: DosQObject, senderFunc: cstring, context: DosQObject, callback: DosQObjectConnectLambdaCallback, data: pointer, connectionType: cint): DosQMetaObjectConnection {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_disconnect_static(sender: DosQObject, senderFunc: cstring, receiver: DosQObject, receiverFunc: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_disconnect_with_connection_static(connection: DosQMetaObjectConnection) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_delete(qobject: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qobject_deleteLater(qobject: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_signal_macro*(name: cstring): cstring {.cdecl, dynlib: dynLibName, importc.}
-proc dos_slot_macro*(name: cstring): cstring {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qvariant_create_int(value: cint): DosQVariant =
+  gen_qvariant.QVariant.create(value)
 
-# QMetaObject::Connection
-proc dos_qmetaobject_connection_delete(connection: DosQMetaObjectConnection) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qvariant_create_int(value: clonglong): DosQVariant =
+  gen_qvariant.QVariant.create(value)
 
-# QAbstractItemModel
-proc dos_qabstractitemmodel_qmetaobject(): DosQMetaObject {.cdecl dynlib: dynLibName, importc.}
+proc dos_qvariant_create_bool(value: bool): DosQVariant =
+  gen_qvariant.QVariant.create(value)
+
+proc dos_qvariant_create_string(value: cstring): DosQVariant =
+  gen_qvariant.QVariant.create(value)
+
+proc dos_qvariant_create_qobject(value: DosQObject): DosQVariant =
+  gen_qvariant.QVariant.fromValue(value)
+
+proc dos_qvariant_create_qvariant(value: DosQVariant): DosQVariant =
+  gen_qvariant.QVariant.create(value)
+
+proc dos_qvariant_create_float(value: cfloat): DosQVariant =
+  gen_qvariant.QVariant.create(value)
+
+proc dos_qvariant_create_double(value: cdouble): DosQVariant =
+  gen_qvariant.QVariant.create(value)
+
+proc dos_qvariant_delete(variant: DosQVariant) =
+  variant.delete()
+
+proc dos_qvariant_isnull(variant: DosQVariant): bool =
+  variant.isNull()
+
+proc dos_qvariant_toInt(variant: DosQVariant): cint =
+  variant.toInt()
+
+proc dos_qvariant_toBool(variant: DosQVariant): bool =
+  variant.toBool()
+
+proc dos_qvariant_toString(variant: DosQVariant): string =
+  variant.toString()
+
+proc dos_qvariant_toDouble(variant: DosQVariant): cdouble =
+  variant.toDouble()
+
+proc dos_qvariant_toFloat(variant: DosQVariant): cfloat =
+  variant.toFloat()
+
+proc dos_qvariant_setInt(variant: DosQVariant, value: cint) =
+  variant.operatorAssign(gen_qvariant.QVariant.create(value))
+
+proc dos_qvariant_setBool(variant: DosQVariant, value: bool) =
+  variant.operatorAssign(gen_qvariant.QVariant.create(value))
+
+proc dos_qvariant_setString(variant: DosQVariant, value: cstring) =
+  variant.operatorAssign(gen_qvariant.QVariant.create(value))
+
+proc dos_qvariant_assign(leftValue: DosQVariant, rightValue: DosQVariant) =
+  leftValue.operatorAssign(rightValue)
+
+proc dos_qvariant_setFloat(variant: DosQVariant, value: cfloat) =
+  variant.operatorAssign(dos_qvariant_create_float(value))
+
+proc dos_qvariant_setDouble(variant: DosQVariant, value: cdouble) =
+  variant.operatorAssign(dos_qvariant_create_double(value))
+
+proc dos_qvariant_setQObject(variant: DosQVariant, value: DosQObject) =
+  variant.operatorAssign(dos_qvariant_create_qobject(value))
 
 # QMetaObject
 proc dos_qmetaobject_create(superclassMetaObject: DosQMetaObject,
                             className: cstring,
                             signalDefinitions: ptr DosSignalDefinitions,
                             slotDefinitions: ptr DosSlotDefinitions,
-                            propertyDefinitions: ptr DosPropertyDefinitions): DosQMetaObject {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmetaobject_delete(vptr: DosQMetaObject) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmetaobject_invoke_method(context: DosQObject, callback: DosQMetaObjectInvokeMethodCallback, callbackData: pointer, connectionType: cint): bool  {.cdecl, dynlib: dynLibName, importc.}
+                            propertyDefinitions: ptr DosPropertyDefinitions): DosQMetaObject =
+  nos_qmetaobject_create(superclassMetaObject, className, signalDefinitions, slotDefinitions, propertyDefinitions)
+proc dos_qmetaobject_delete(vptr: DosQMetaObject) =
+  vptr.delete()
+
+# QObject
+proc dos_qobject_qmetaobject(): DosQMetaObject =
+  var signalDefs: DosSignalDefinitions
+  var slotDefs: DosSlotDefinitions
+  var propDefs: DosPropertyDefinitions
+
+  dos_qmetaobject_create(
+    gen_qobject.QObject.staticMetaObject(),
+    "DosQObject",
+    addr signalDefs,
+    addr slotDefs,
+    addr propDefs,
+  )
+proc dos_qobject_create(nimobject: NimQObject, metaObject: DosQMetaObject, dosQObjectCallback: DosQObjectCallBack): DosQObject =
+  let vtbl = new QObjectVtable
+  gen_qobject.QObject.setupCallbacks(
+    nimobject, metaObject, dosQObjectCallback, vtbl[], QObjectmetacall
+  )
+
+  gen_qobject.QObject.create(vtbl = vtbl)
+
+proc dos_qobject_objectName(qobject: DosQObject): cstring =
+  debugEcho "dos_qobject_objectName(qobject: DosQObject): cstring "
+
+proc dos_qobject_setObjectName(qobject: DosQObject, name: cstring) =
+  qobject.setObjectName($name)
+proc dos_qobject_signal_emit(qobject: DosQObject, signalName: cstring, argumentsCount: cint, arguments: ptr DosQVariantArray) =
+  let mo = qobject.metaObject()
+
+  for i in 0 ..< mo.methodCount:
+    let meth = mo.methodX(cint(i))
+    if meth.parameterCount() == argumentsCount and signalName.toOpenArrayByte(0, len(signalName) - 1) == meth.name:
+
+      var argv = newSeq[pointer](argumentsCount + 1)
+      for i in 0 ..< argumentsCount:
+        argv[i + 1] = arguments[i].constData()
+      gen_qobjectdefs.QMetaObject.activate(qobject, cint i, addr argv[0])
+      break
+
+proc dos_qobject_connect_static(
+    sender: DosQObject,
+    senderFunc: cstring,
+    receiver: DosQObject,
+    receiverFunc: cstring,
+    connectionType: cint,
+): DosQMetaObjectConnection =
+  receiver.connect(sender, senderFunc, receiverFunc)
+
+proc dos_qobject_connect_lambda_static(
+    sender: DosQObject,
+    senderFunc: cstring,
+    callback: DosQObjectConnectLambdaCallback,
+    data: pointer,
+    connectionType: cint,
+): DosQMetaObjectConnection =
+  nos_qobject_connect_lambda_with_context_static(sender, senderFunc, sender, callback, data, connectionType)
+proc dos_qobject_connect_lambda_with_context_static(
+    sender: DosQObject,
+    senderFunc: cstring,
+    context: DosQObject,
+    callback: DosQObjectConnectLambdaCallback,
+    data: pointer,
+    connectionType: cint,
+): DosQMetaObjectConnection =
+  nos_qobject_connect_lambda_with_context_static(sender, senderFunc, context, callback, data, connectionType)
+
+proc dos_qobject_disconnect_static(
+    sender: DosQObject, senderFunc: cstring, receiver: DosQObject, receiverFunc: cstring
+) =
+  debugEcho "dos_qobject_disconnect_static"
+
+proc dos_qobject_disconnect_with_connection_static(connection: DosQMetaObjectConnection) =
+  discard QObject.disconnect(connection)
+
+proc dos_qobject_delete(qobject: DosQObject) =
+  qobject.delete()
+
+proc dos_qobject_deleteLater(qobject: DosQObject) =
+  qobject.deleteLater()
+
+# QMetaObject::Connection
+proc dos_qmetaobject_connection_delete(connection: DosQMetaObjectConnection) =
+  connection.delete()
+
+proc dos_qmetaobject_invoke_method(
+    context: DosQObject,
+    callback: DosQMetaObjectInvokeMethodCallback,
+    callbackData: pointer,
+    connectionType: cint,
+): bool =
+  debugEcho "dos_qmetaobject_invoke_method"
+
+# QAbstractItemModel
+proc dos_qabstractitemmodel_qmetaobject(): DosQMetaObject =
+  var signalDefs: DosSignalDefinitions
+  var slotDefs: DosSlotDefinitions
+  var propDefs: DosPropertyDefinitions
+
+  dos_qmetaobject_create(
+    gen_qabstractitemmodel.QAbstractItemModel.staticMetaObject(),
+    "DosQAbstractItemModel",
+    addr signalDefs,
+    addr slotDefs,
+    addr propDefs,
+  )
 
 # QUrl
-proc dos_qurl_create(url: cstring, parsingMode: cint): DosQUrl {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qurl_delete(vptr: DosQUrl) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qurl_to_string(vptr: DosQUrl): cstring {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qurl_create(url: cstring, parsingMode: cint): DosQUrl =
+  QUrl.create($url, parsingMode)
+
+proc dos_qurl_delete(vptr: DosQUrl) =
+  vptr.delete()
+
+proc dos_qurl_to_string(vptr: DosQUrl): string =
+  vptr.toString()
 
 # QQuickView
-proc dos_qquickview_create(): DosQQuickView {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qquickview_delete(view: DosQQuickView) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qquickview_show(view: DosQQuickView) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qquickview_source(view: DosQQuickView): cstring {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qquickview_set_source(view: DosQQuickView, filename: cstring) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qquickview_create(): DosQQuickView =
+  debugEcho "dos_qquickview_create(): DosQQuickView "
+
+proc dos_qquickview_delete(view: DosQQuickView) =
+  debugEcho "dos_qquickview_delete(view: DosQQuickView) "
+
+proc dos_qquickview_show(view: DosQQuickView) =
+  debugEcho "dos_qquickview_show(view: DosQQuickView) "
+
+proc dos_qquickview_source(view: DosQQuickView): cstring =
+  debugEcho "dos_qquickview_source(view: DosQQuickView): cstring "
+
+proc dos_qquickview_set_source(view: DosQQuickView, filename: cstring) =
+  debugEcho "dos_qquickview_set_source(view: DosQQuickView, filename: cstring) "
 
 # QHash<int, QByteArra>
-proc dos_qhash_int_qbytearray_create(): DosQHashIntByteArray {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qhash_int_qbytearray_delete(qHash: DosQHashIntByteArray) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qhash_int_qbytearray_insert(qHash: DosQHashIntByteArray, key: int, value: cstring) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qhash_int_qbytearray_value(qHash: DosQHashIntByteArray, key: int): cstring {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qhash_int_qbytearray_create(): DosQHashIntByteArray =
+  debugEcho "dos_qhash_int_qbytearray_create(): DosQHashIntByteArray "
+
+proc dos_qhash_int_qbytearray_delete(qHash: DosQHashIntByteArray) =
+  debugEcho "dos_qhash_int_qbytearray_delete(qHash: DosQHashIntByteArray) "
+
+proc dos_qhash_int_qbytearray_insert(
+    qHash: DosQHashIntByteArray, key: int, value: cstring
+) =
+  debugEcho "dos_qhash_int_qbytearray_insert(qHash: DosQHashIntByteArray, key: int, value: cstring) "
+
+proc dos_qhash_int_qbytearray_value(qHash: DosQHashIntByteArray, key: int): cstring =
+  debugEcho "dos_qhash_int_qbytearray_value(qHash: DosQHashIntByteArray, key: int): cstring "
 
 # QModelIndex
-proc dos_qmodelindex_create(): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_create_qmodelindex(other: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_delete(modelIndex: DosQModelIndex) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_row(modelIndex: DosQModelIndex): cint {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_column(modelIndex: DosQModelIndex): cint {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_isValid(modelIndex: DosQModelIndex): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_data(modelIndex: DosQModelIndex, role: cint): DosQVariant {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_parent(modelIndex: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_child(modelIndex: DosQModelIndex, row: cint, column: cint): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_sibling(modelIndex: DosQModelIndex, row: cint, column: cint): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_assign(leftSide: DosQModelIndex, rightSide: DosQModelIndex) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qmodelindex_internalPointer(modelIndex: DosQModelIndex): pointer {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qmodelindex_create(): DosQModelIndex =
+  gen_qabstractitemdelegate.QModelIndex.create()
+
+proc dos_qmodelindex_create_qmodelindex(other: DosQModelIndex): DosQModelIndex =
+  gen_qabstractitemdelegate.QModelIndex.create(other)
+
+proc dos_qmodelindex_delete(modelIndex: DosQModelIndex) =
+  modelIndex.delete()
+
+proc dos_qmodelindex_row(modelIndex: DosQModelIndex): cint =
+  modelIndex.row()
+
+proc dos_qmodelindex_column(modelIndex: DosQModelIndex): cint =
+  modelIndex.column()
+
+proc dos_qmodelindex_isValid(modelIndex: DosQModelIndex): bool =
+  modelIndex.isValid()
+
+proc dos_qmodelindex_data(modelIndex: DosQModelIndex, role: cint): DosQVariant =
+  modelIndex.data(role)
+
+proc dos_qmodelindex_parent(modelIndex: DosQModelIndex): DosQModelIndex =
+  modelIndex.parent()
+
+proc dos_qmodelindex_child(
+    modelIndex: DosQModelIndex, row: cint, column: cint
+): DosQModelIndex =
+  modelIndex.child(row, column)
+
+proc dos_qmodelindex_sibling(
+    modelIndex: DosQModelIndex, row: cint, column: cint
+): DosQModelIndex =
+  modelIndex.sibling(row, column)
+
+proc dos_qmodelindex_assign(leftSide: var DosQModelIndex, rightSide: DosQModelIndex) =
+  if not isNil(pointer(leftSide)): leftSide.delete()
+  leftSide = gen_qabstractitemmodel.QModelIndex.create(rightSide)
+
+proc dos_qmodelindex_internalPointer(modelIndex: DosQModelIndex): pointer =
+  modelIndex.internalPointer()
 
 # QAbstractItemModel
 proc dos_qabstractitemmodel_create(modelPtr: NimQAbstractItemModel,
                                    metaObject: DosQMetaObject,
                                    qobjectCallback: DosQObjectCallBack,
-                                   qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractItemModel {.cdecl, dynlib: dynLibName, importc.}
+                                   qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractItemModel =
+  let vtbl = new QAbstractItemModelVTable
+  gen_qabstractitemmodel.QAbstractItemModel.setupCallbacks(
+    modelPtr, metaObject, qobjectCallback, vtbl[], QAbstractItemModelmetacall
+  )
+  gen_qabstractitemmodel.QAbstractItemModel.setupCallbacks(
+    modelPtr, qaimCallbacks, vtbl[]
+  )
+
+  gen_qabstractitemmodel.QAbstractItemModel.create(vtbl)
 
 proc dos_qabstractitemmodel_beginInsertRows(model: DosQAbstractItemModel,
                                             parentIndex: DosQModelIndex,
                                             first: cint,
-                                            last: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_endInsertRows(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
+                                            last: cint) =
+  model.beginInsertRows(parentIndex, first, last)
+
+proc dos_qabstractitemmodel_endInsertRows(model: DosQAbstractItemModel) =
+  model.endInsertRows()
+
 proc dos_qabstractitemmodel_beginRemoveRows(model: DosQAbstractItemModel,
                                             parentIndex: DosQModelIndex,
                                             first: cint,
-                                            last: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_endRemoveRows(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
+                                            last: cint) =
+  model.beginRemoveRows(parentIndex,first, last)
+
+proc dos_qabstractitemmodel_endRemoveRows(model: DosQAbstractItemModel) =
+  model.endRemoveRows()
+
 proc dos_qabstractitemmodel_beginInsertColumns(model: DosQAbstractItemModel,
                                                parentIndex: DosQModelIndex,
                                                first: cint,
-                                               last: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_endInsertColumns(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
+                                               last: cint) =
+  model.beginInsertColumns(parentIndex, first, last)
+
+proc dos_qabstractitemmodel_endInsertColumns(model: DosQAbstractItemModel) =
+  model.endInsertColumns()
+
 proc dos_qabstractitemmodel_beginRemoveColumns(model: DosQAbstractItemModel,
                                                parentIndex: DosQModelIndex,
                                                first: cint,
-                                               last: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_endRemoveColumns(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_beginResetModel(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_endResetModel(model: DosQAbstractItemModel) {.cdecl, dynlib: dynLibName, importc.}
+                                               last: cint) =
+  model.beginRemoveColumns(parentIndex, first, last)
+
+proc dos_qabstractitemmodel_endRemoveColumns(model: DosQAbstractItemModel) =
+  model.endRemoveColumns()
+
+proc dos_qabstractitemmodel_beginResetModel(model: DosQAbstractItemModel) =
+  model.beginResetModel()
+
+proc dos_qabstractitemmodel_endResetModel(model: DosQAbstractItemModel) =
+  model.endResetModel()
+
 proc dos_qabstractitemmodel_dataChanged(model: DosQAbstractItemModel,
                                         parentLeft: DosQModelIndex,
                                         bottomRight: DosQModelIndex,
                                         rolesArrayPtr: ptr cint,
-                                        rolesArrayLength: cint) {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_createIndex(model: DosQAbstractItemModel, row: cint, column: cint, data: pointer): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_hasChildren(model: DosQAbstractItemModel, parent: DosQModelIndex): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_hasIndex(model: DosQAbstractItemModel, row: int, column: int, parent: DosQModelIndex): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_canFetchMore(model: DosQAbstractItemModel, parent: DosQModelIndex): bool {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractitemmodel_fetchMore(model: DosQAbstractItemModel, parent: DosQModelIndex) {.cdecl, dynlib: dynLibName, importc.}
+                                        rolesArrayLength: cint) =
+  model.dataChanged(parentLeft, bottomRight, @(cast[ptr UncheckedArray[cint]](rolesArrayPtr).toOpenArray(0, rolesArrayLength-1)) )
 
+proc dos_qabstractitemmodel_createIndex(model: DosQAbstractItemModel, row: cint, column: cint, data: pointer): DosQModelIndex =
+  model.createIndex(row, column, cast[uint](data))
+
+proc dos_qabstractitemmodel_hasChildren(model: DosQAbstractItemModel, parent: DosQModelIndex): bool =
+  model.QAbstractItemModelhasChildren(parent)
+
+proc dos_qabstractitemmodel_hasIndex(model: DosQAbstractItemModel, row: int, column: int, parent: DosQModelIndex): bool =
+  model.hasIndex(cint row, cint column, parent)
+
+proc dos_qabstractitemmodel_canFetchMore(model: DosQAbstractItemModel, parent: DosQModelIndex): bool =
+  QAbstractItemModelcanFetchMore(model, parent)
+
+proc dos_qabstractitemmodel_fetchMore(model: DosQAbstractItemModel, parent: DosQModelIndex) =
+  QAbstractItemModelfetchMore(model, parent)
 
 # QResource
-proc dos_qresource_register(filename: cstring) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qresource_register(filename: cstring) =
+  discard QResource.registerResource($filename)
 
 # QDeclarative
-proc dos_qdeclarative_qmlregistertype(value: ptr DosQmlRegisterType): cint {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qdeclarative_qmlregistersingletontype(value: ptr DosQmlRegisterType): cint {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qdeclarative_qmlregistertype(value: ptr DosQmlRegisterType): cint =
+  debugEcho "dos_qdeclarative_qmlregistertype(value: ptr DosQmlRegisterType): cint "
+
+proc dos_qdeclarative_qmlregistersingletontype(value: ptr DosQmlRegisterType): cint =
+  debugEcho "dos_qdeclarative_qmlregistersingletontype(value: ptr DosQmlRegisterType): cint "
 
 # QAbstractListModel
-proc dos_qabstractlistmodel_qmetaobject(): DosQMetaObject {.cdecl dynlib: dynLibName, importc.}
+proc dos_qabstractlistmodel_qmetaobject(): DosQMetaObject =
+  var signalDefs: DosSignalDefinitions
+  var slotDefs: DosSlotDefinitions
+  var propDefs: DosPropertyDefinitions
+
+  dos_qmetaobject_create(
+    gen_qabstractitemmodel.QAbstractListModel.staticMetaObject(),
+    "DosQAbstractListModel",
+    addr signalDefs,
+    addr slotDefs,
+    addr propDefs,
+  )
 
 proc dos_qabstractlistmodel_create(modelPtr: NimQAbstractListModel,
                                    metaObject: DosQMetaObject,
                                    qobjectCallback: DosQObjectCallBack,
-                                   qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractListModel {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractlistmodel_columnCount(modelPtr: DosQAbstractListModel, index: DosQModelIndex): cint {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractlistmodel_parent(modelPtr: DosQAbstractListModel, index: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstractlistmodel_index(modelPtr: DosQAbstractListModel, row: cint, column: cint, parent: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
+                                   qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractListModel =
+  let vtbl = new QAbstractListModelVTable
+  gen_qabstractitemmodel.QAbstractListModel.setupCallbacks(
+    modelPtr, metaObject, qobjectCallback, vtbl[], QAbstractListModelmetacall
+  )
+  gen_qabstractitemmodel.QAbstractListModel.setupCallbacks(
+    modelPtr, qaimCallbacks, vtbl[]
+  )
+
+  gen_qabstractitemmodel.QAbstractListModel.create(vtbl = vtbl)
+
+proc dos_qabstractlistmodel_columnCount(modelPtr: DosQAbstractListModel, index: DosQModelIndex): cint =
+  QAbstractListModel(modelPtr).columnCount(index)
+
+proc dos_qabstractlistmodel_parent(modelPtr: DosQAbstractListModel, index: DosQModelIndex): DosQModelIndex =
+  QAbstractListModel(modelPtr).parent(index)
+
+proc dos_qabstractlistmodel_index(modelPtr: DosQAbstractListModel, row: cint, column: cint, parent: DosQModelIndex): DosQModelIndex =
+  modelPtr.QAbstractListModelindex(row, column, parent)
 
 # QAbstractTableModel
-proc dos_qabstracttablemodel_qmetaobject(): DosQMetaObject {.cdecl dynlib: dynLibName, importc.}
+proc dos_qabstracttablemodel_qmetaobject(): DosQMetaObject =
+  var signalDefs: DosSignalDefinitions
+  var slotDefs: DosSlotDefinitions
+  var propDefs: DosPropertyDefinitions
+
+  dos_qmetaobject_create(
+    gen_qabstractitemmodel.QAbstractTableModel.staticMetaObject(),
+    "DosQAbstractTableModel",
+    addr signalDefs,
+    addr slotDefs,
+    addr propDefs,
+  )
+
 proc dos_qabstracttablemodel_create(modelPtr: NimQAbstractTableModel,
                                     metaObject: DosQMetaObject,
                                     qobjectCallback: DosQObjectCallBack,
-                                    qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractTableModel {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstracttablemodel_parent(modelPtr: DosQAbstractTableModel, index: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
-proc dos_qabstracttablemodel_index(modelPtr: DosQAbstractTableModel, row: cint, column: cint, parent: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
+                                    qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractTableModel=
+  let vtbl = new QAbstractTableModelVTable
+  gen_qabstractitemmodel.QAbstractTableModel.setupCallbacks(
+    modelPtr, metaObject, qobjectCallback, vtbl[], QAbstractTableModelmetacall
+  )
+  gen_qabstractitemmodel.QAbstractTableModel.setupCallbacks(
+    modelPtr, qaimCallbacks, vtbl[]
+  )
+
+  gen_qabstractitemmodel.QAbstractTableModel.create(vtbl = vtbl)
+
+proc dos_qabstracttablemodel_parent(modelPtr: DosQAbstractTableModel, index: DosQModelIndex): DosQModelIndex =
+  QAbstractTableModel(modelPtr).parent(index)
+
+proc dos_qabstracttablemodel_index(modelPtr: DosQAbstractTableModel, row: cint, column: cint, parent: DosQModelIndex): DosQModelIndex =
+  QAbstractTableModel(modelPtr).index(row, column, parent)
+
+{.pop.}

--- a/src/nimqml/private/nimqmlmacros.nim
+++ b/src/nimqml/private/nimqmlmacros.nim
@@ -123,8 +123,8 @@ proc getPragmas(n: NimNode): seq[string] {.compiletime.} =
     return
   let pragma = pragmas[0]
   for c in pragma:
-    doAssert(c.kind in {nnkSym, nnkIdent})
-    result.add($c)
+    if c.kind in {nnkSym, nnkIdent}:
+      result.add($c)
 
 proc extractQObjectTypeDef(head: NimNode): FindQObjectTypeResult {.compiletime.} =
   ## Extract the first type section and extract the first type Name and SuperType
@@ -509,7 +509,7 @@ proc isQObject(impl: NimNode): bool {.compileTime.} =
   ## Return true if the type is a QObject
   var typ = impl
   while typ.kind == nnkTypeDef:
-    let name = typ[0]
+    let name = typ[0].basename()
     if $name == "QObject":
       return true
     typ = superClass(typ)

--- a/src/nimqml/private/notherside.nim
+++ b/src/nimqml/private/notherside.nim
@@ -1,0 +1,425 @@
+import
+  gen_qabstractitemdelegate,
+  gen_qabstractitemmodel,
+  gen_qapplication,
+  gen_qmetatype,
+  gen_qmetaobject,
+  gen_qobject,
+  gen_qobjectdefs,
+  gen_qresource,
+  gen_qurl,
+  gen_qvariant,
+  quick/gen_qqmlapplicationengine,
+  quick/gen_qqmlcomponent,
+  quick/gen_qqmlcontext,
+  quick/gen_qquickview,
+  ../../nimside
+
+converter toQAbstractItemModel*(
+    v: gen_qabstractitemmodel_types.QAbstractItemModel
+): DosQAbstractItemModel =
+  DosQAbstractItemModel(v.h)
+
+converter toQAbstractItemModel*(
+    v: DosQAbstractItemModel
+): gen_qabstractitemmodel_types.QAbstractItemModel =
+  gen_QAbstractItemModel_types.QAbstractItemModel(h: pointer(v))
+
+converter toQAbstractListModel*(
+    v: gen_qabstractitemmodel_types.QAbstractListModel
+): DosQAbstractListModel =
+  DosQAbstractListModel(v.h)
+
+converter toQAbstractListModel*(
+    v: DosQAbstractListModel
+): gen_qabstractitemmodel_types.QAbstractListModel =
+  gen_QAbstractItemModel_types.QAbstractListModel(h: pointer(v))
+
+converter toQAbstractTableModel*(
+    v: gen_qabstractitemmodel_types.QAbstractTableModel
+): DosQAbstractTableModel =
+  DosQAbstractTableModel(v.h)
+
+converter toQAbstractTableModel*(
+    v: DosQAbstractTableModel
+): gen_qabstractitemmodel_types.QAbstractTableModel =
+  gen_QAbstractItemModel_types.QAbstractTableModel(h: pointer(v))
+
+converter toQQmlApplicationEngine*(
+    v: gen_qqmlapplicationengine_types.QQmlApplicationEngine
+): DosQQmlApplicationEngine =
+  DosQQmlApplicationEngine(v.h)
+
+converter toQQmlApplicationEngine*(
+    v: DosQQmlApplicationEngine
+): gen_qqmlapplicationengine_types.QQmlApplicationEngine =
+  gen_qqmlapplicationengine_types.QQmlApplicationEngine(h: pointer(v))
+
+converter toQQmlContext*(v: gen_qqmlcontext_types.QQmlContext): DosQQmlContext =
+  DosQQmlContext(v.h)
+
+converter toQQmlContext*(v: DosQQmlContext): gen_qqmlcontext_types.QQmlContext =
+  gen_qqmlcontext_types.QQmlContext(h: pointer(v))
+
+converter toQQmlEngine*(v: DosQQmlApplicationEngine): gen_qQmlEngine_types.QQmlEngine =
+  gen_qQmlEngine_types.QQmlEngine(h: pointer(v))
+
+converter toQMetaObject*(v: gen_qobjectdefs_types.QMetaObject): DosQMetaObject =
+  DosQMetaObject(v.h)
+
+converter toQMetaObject*(v: DosQMetaObject): gen_qobjectdefs_types.QMetaObject =
+  gen_qobjectdefs_types.QMetaObject(h: pointer(v))
+
+converter toQMetaObjectConnection*(
+    v: gen_qobjectdefs_types.QMetaObjectConnection
+): DosQMetaObjectConnection =
+  DosQMetaObjectConnection(v.h)
+
+converter toQMetaObjectConnection*(
+    v: DosQMetaObjectConnection
+): gen_qobjectdefs_types.QMetaObjectConnection =
+  gen_qobjectdefs_types.QMetaObjectConnection(h: pointer(v))
+
+converter toQModelIndex*(v: gen_qabstractitemmodel_types.QModelIndex): DosQModelIndex =
+  DosQModelIndex(v.h)
+
+converter toQModelIndex*(v: DosQModelIndex): gen_qabstractitemmodel_types.QModelIndex =
+  gen_qabstractitemmodel_types.QModelIndex(h: pointer(v))
+
+converter toQObject*(v: gen_qobject_types.QObject): DosQObject =
+  DosQObject(v.h)
+
+converter toQObject*(v: DosQObject): gen_qobject_types.QObject =
+  gen_qobject_types.QObject(h: pointer(v))
+
+converter toQUrl*(v: gen_qurl_types.QUrl): DosQUrl =
+  DosQUrl(v.h)
+
+converter toQQrl*(v: DosQUrl): gen_qurl_types.QUrl =
+  gen_qurl_types.QUrl(h: pointer(v))
+
+converter toQVariant*(v: gen_qvariant_types.QVariant): DosQVariant =
+  DosQVariant(v.h)
+
+converter toQVariant*(v: DosQVariant): gen_qvariant.QVariant =
+  gen_qvariant_types.QVariant(h: pointer(v))
+
+from system/ansi_c import c_calloc, c_free
+
+# TODO Get rid of this - but it requires changing the dos_* interface significantly
+import std/tables
+var classProps {.threadvar.}: Table[string, QMetaMethod]
+
+proc classLookup(mo: gen_qobjectdefs_types.QMetaObject, id: cint, read: bool): string =
+  repr(mo.h) & $id & $read
+
+proc findProp(
+    mo: gen_qobjectdefs_types.QMetaObject, id: cint, read: bool
+): QMetaMethod =
+  try:
+    classProps[classLookup(mo, id, read)]
+  except CatchableError as exc:
+    raiseAssert exc.msg
+
+template noExceptions(body: untyped): untyped =
+  try:
+    {.gcsafe.}:
+      body
+  except Defect as e:
+    raise e
+  except Exception as e:
+    raiseAssert(e.msg & "\n" & e.getStackTrace())
+
+proc nos_qmetaobject_create(
+    superclassMetaObject: gen_qobjectdefs_types.QMetaObject,
+    className: cstring,
+    signalDefinitions: ptr DosSignalDefinitions,
+    slotDefinitions: ptr DosSlotDefinitions,
+    propertyDefinitions: ptr DosPropertyDefinitions,
+): DosQMetaObject =
+  template params(
+      s: DosSignalDefinition | DosSlotDefinition
+  ): openArray[DosParameterDefinition] =
+    let p = cast[ptr UncheckedArray[DosParameterDefinition]](s.parameters)
+    p.toOpenArray(0, s.parametersCount.int - 1)
+
+  let
+    signalDefs =
+      cast[ptr UncheckedArray[DosSignalDefinition]](signalDefinitions.definitions)
+    slotDefs = cast[ptr UncheckedArray[DosSlotDefinition]](slotDefinitions.definitions)
+    propertyDefs =
+      cast[ptr UncheckedArray[DosPropertyDefinition]](propertyDefinitions.definitions)
+
+    signals = mapIt(
+      signalDefs.toOpenArray(0, signalDefinitions.count.int - 1),
+      MethodDef.signalDef(
+        $it.name, it.params.mapIt(ParamDef(name: $it.name, metaType: it.metaType))
+      ),
+    )
+    slots = mapIt(
+      slotDefs.toOpenArray(0, slotDefinitions.count.int - 1),
+      MethodDef.slotDef(
+        $it.name,
+        it.returnMetaType,
+        it.params.mapIt(ParamDef(name: $it.name, metaType: it.metaType)),
+      ),
+    )
+    props = mapIt(
+      propertyDefs.toOpenArray(0, propertyDefinitions.count.int - 1),
+      PropertyDef(
+        name: $it.name,
+        metaType: it.propertyMetaType,
+        readSlot: $it.readSlot,
+        writeSlot: $it.writeSlot,
+        notifySignal: $it.notifySignal,
+      ),
+    )
+
+  let tmp = genMetaObject(superclassMetaObject, $className, signals, slots, props)
+
+  block:
+    for i in 0 ..< propertyDefinitions.count:
+      let prop = propertyDefs[i]
+      if prop.readSlot != nil:
+        for j in 0 ..< slotDefinitions.count:
+          if slotDefs[j].name == prop.readSlot:
+            classProps[classLookup(tmp, i, true)] = tmp.methodX(
+              superclassMetaObject.methodCount() + j + signalDefinitions.count
+            )
+
+      if prop.writeSlot != nil:
+        for j in 0 ..< slotDefinitions.count:
+          if slotDefs[j].name == prop.writeSlot:
+            classProps[classLookup(tmp, i, false)] = tmp.methodX(
+              superclassMetaObject.methodCount() + j + signalDefinitions.count
+            )
+
+  tmp
+
+template setupCallbacks[MC](
+    T: type,
+    nimobjectParam: NimQObject,
+    metaObjectParam: DosQMetaObject,
+    dosQObjectCallbackParam: DosQObjectCallBack,
+    vtbl: auto,
+    superMc: proc(self: MC, c: cint, index: cint, param3: pointer): cint {.
+      raises: [], nimcall
+    .},
+) =
+  func fromBytes(_: type string, v: openArray[byte]): string =
+    if v.len > 0:
+      result = newString(v.len)
+      when nimvm:
+        for i, c in v:
+          result[i] = cast[char](c)
+      else:
+        copyMem(addr result[0], unsafeAddr v[0], v.len)
+
+  vtbl.metacall = proc(
+      self: T, c: cint, index: cint, param3: pointer
+  ): cint {.closure, raises: [], gcsafe.} =
+    let id = superMc(self, c, index, param3)
+    if id < 0:
+      return id
+
+    let mo = metaObjectParam
+
+    template callQObjectCallback(meth: QMetaMethod, offset: int) =
+      let name = gen_qvariant.QVariant.create(string.fromBytes(meth.name()))
+      var args = newSeq[DosQVariant](meth.parameterCount() + 1)
+      args[0] = gen_qvariant.QVariant.create()
+
+      for i in cint(0) ..< meth.parameterCount():
+        args[i + 1] =
+          gen_qvariant.QVariant.create(meth.parameterType(i), argv[int(i + offset)])
+      dosQObjectCallbackParam(
+        nimobjectParam, name, cint args.len, cast[ptr DosQVariantArray](addr args[0])
+      )
+      if meth.returnType() != QMetaTypeTypeEnum.Void and args[0].isValid():
+        discard QMetaType.construct(meth.returnType(), argv[0], args[0].constData())
+
+      for v in args:
+        v.delete()
+
+    noExceptions:
+      var argv {.inject.} = cast[ptr UncheckedArray[pointer]](param3)
+      case c
+      of QMetaObjectCallEnum.InvokeMetaMethod:
+        if index < mo.methodCount():
+          let meth = mo.methodX(index)
+          callQObjectCallback(meth, 1)
+
+        id - (mo.methodCount() - mo.methodOffset())
+      of QMetaObjectCallEnum.RegisterMethodArgumentMetaType:
+        id - (mo.methodCount() - mo.methodOffset())
+      of QMetaObjectCallEnum.ReadProperty:
+        if index < mo.propertyCount():
+          let property = mo.property(index)
+          if property.isValid() and property.isReadable():
+            let meth = findProp(mo, id, true)
+            callQObjectCallback(meth, 1)
+
+        id - (mo.propertyCount() - mo.propertyOffset())
+      of QMetaObjectCallEnum.WriteProperty:
+        if index < mo.propertyCount():
+          let property = mo.property(index)
+          if property.isValid() and property.isWritable():
+            let meth = findProp(mo, id, false)
+            callQObjectCallback(meth, 0)
+
+        id - (mo.propertyCount() - mo.propertyOffset())
+      of QMetaObjectCallEnum.ResetProperty,
+          QMetaObjectCallEnum.RegisterPropertyMetaType,
+          QMetaObjectCallEnum.QueryPropertyDesignable,
+          QMetaObjectCallEnum.QueryPropertyScriptable,
+          QMetaObjectCallEnum.QueryPropertyStored,
+          QMetaObjectCallEnum.QueryPropertyEditable,
+          QMetaObjectCallEnum.QueryPropertyUser:
+        id - (mo.propertyCount() - mo.propertyOffset())
+      else:
+        id
+
+  vtbl.metaObject = proc(
+      self: T
+  ): gen_qobjectdefs.QMetaObject {.closure, raises: [], gcsafe.} =
+    metaObjectParam
+
+template setupCallbacks(
+    T: type,
+    modelPtr: NimQAbstractListModel,
+    qaimCallbacks: DosQAbstractItemModelCallbacks,
+    vtbl:
+      QAbstractItemModelVTable | QAbstractListModelVTable | QAbstractTableModelVtable,
+) =
+  if qaimCallbacks.rowCount != nil:
+    vtbl.rowCount = proc(self: T, parent: QModelIndex): cint =
+      noExceptions:
+        var v: cint
+        qaimCallbacks.rowCount(modelPtr, parent, v)
+        v
+
+  when T is gen_qabstractitemmodel.QAbstractTableModel:
+    if qaimCallbacks.columnCount != nil:
+      vtbl.columnCount = proc(self: T, parent: QModelIndex): cint =
+        noExceptions:
+          var v: cint
+          qaimCallbacks.columnCount(modelPtr, parent, v)
+          v
+
+  if qaimCallbacks.data != nil:
+    vtbl.data = proc(self: T, index: QModelIndex, role: cint): gen_qvariant.QVariant =
+      noExceptions:
+        var v = gen_qvariant.QVariant.create()
+        qaimCallbacks.data(modelPtr, index, role, v)
+        v
+
+  if qaimCallbacks.setData != nil:
+    vtbl.setData = proc(
+        self: T, index: QModelIndex, value: gen_qvariant.QVariant, role: cint
+    ): bool =
+      noExceptions:
+        var v: bool
+        qaimCallbacks.setData(modelPtr, index, value, role, v)
+        v
+
+  if qaimCallbacks.roleNames != nil:
+    vtbl.roleNames = proc(self: T): tables.Table[cint, seq[byte]] =
+      noExceptions:
+        qaimCallbacks.roleNames(modelPtr)
+
+  if qaimCallbacks.flags != nil:
+    vtbl.flags = proc(self: T, index: QModelIndex): cint =
+      noExceptions:
+        var v: cint
+        qaimCallbacks.flags(modelPtr, index, v)
+        v
+
+  if qaimCallbacks.headerData != nil:
+    vtbl.headerData = proc(
+        self: T, section: cint, orientation: cint, role: cint
+    ): gen_qvariant.QVariant =
+      noExceptions:
+        var v = gen_qvariant.QVariant.create()
+        qaimCallbacks.headerData(modelPtr, section, orientation, role, v)
+        v
+  if qaimCallbacks.index != nil:
+    vtbl.index =
+      when T is QAbstractItemModel:
+        proc(
+            self: T, row: cint, column: cint, parent: QModelIndex
+        ): QModelIndex {.closure.} =
+          noExceptions:
+            var v: DosQModelIndex
+            qaimCallbacks.index(modelPtr, row, column, parent, v)
+            v
+      else:
+        proc(
+            self: T, row: cint, column: cint, parent: QModelIndex
+        ): QModelIndex {.closure.} =
+          noExceptions:
+            var v: DosQModelIndex
+            qaimCallbacks.index(modelPtr, row, column, parent, v)
+            v
+
+  when T isnot gen_qabstractitemmodel.QAbstractListModel and
+      T isnot gen_qabstractitemmodel.QAbstractTableModel:
+    if qaimCallbacks.parent != nil:
+      vtbl.parent = proc(self: T, child: QModelIndex): QModelIndex =
+        noExceptions:
+          var v: DosQModelIndex
+          qaimCallbacks.parent(modelPtr, child, v)
+          v
+
+    if qaimCallbacks.hasChildren != nil:
+      vtbl.hasChildren = proc(self: T, child: QModelIndex): bool =
+        noExceptions:
+          var v: bool
+          qaimCallbacks.hasChildren(modelPtr, child, v)
+          v
+
+  if qaimCallbacks.canFetchMore != nil:
+    vtbl.canFetchMore = proc(self: T, parentX: QModelIndex): bool {.closure, gcsafe.} =
+      noExceptions:
+        var v: bool
+        qaimCallbacks.canFetchMore(modelPtr, parentX, v)
+        v
+
+  if qaimCallbacks.fetchMore != nil:
+    vtbl.fetchMore = proc(self: T, parentX: QModelIndex) {.closure, gcsafe.} =
+      noExceptions:
+        qaimCallbacks.fetchMore(modelPtr, parentX)
+
+proc nos_qobject_connect_lambda_with_context_static(
+    sender: gen_qobject_types.QObject,
+    senderFunc: cstring,
+    context: gen_qobject_types.QObject,
+    callback: DosQObjectConnectLambdaCallback,
+    data: pointer,
+    connectionType: cint,
+): gen_qobjectdefs_types.QMetaObjectConnection =
+  var meta = sender.metaObject()
+  var senderFunc = $senderFunc
+  let meth = meta.methodX(meta.indexOfSignal(cstring(senderFunc[1 ..^ 1])))
+  let numArguments = meth.parameterCount()
+
+  var tmp = new QObject_connectSlot
+  tmp[] = proc(argv: pointer) =
+    let argv = cast[ptr UncheckedArray[pointer]](argv)
+    var args = newSeq[DosQVariant](meth.parameterCount())
+    for i in cint(0) ..< cint(args.len):
+      args[i] = gen_qvariant.QVariant.create(meth.parameterType(i), argv[int(i) + 1])
+    noExceptions:
+      callback(data, cint args.len, cast[ptr DosQVariantArray](addr args[0]))
+
+  GC_ref(tmp)
+  gen_qobjectdefs_types.QMetaObjectConnection(
+    h: QObject_connectRawSlot(
+      sender.h,
+      cstring(senderFunc),
+      context.h,
+      cast[int](addr(tmp[])),
+      nil,
+      connectionType,
+      sender.metaObject().h,
+    )
+  )

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -60,12 +60,12 @@ method roleNames*(self: QAbstractItemModel): Table[int, string] {.base.} =
   ## Return the model role names
   nil
 
-proc roleNamesCallback(modelPtr: pointer, hash: DosQHashIntByteArray) {.cdecl, exportc.} =
+proc roleNamesCallback(modelPtr: pointer): Table[cint, seq[byte]] {.cdecl, exportc.} =
   debugMsg("QAbstractItemModel", "roleNamesCallback")
   let model = cast[QAbstractItemModel](modelPtr)
   let table = model.roleNames()
   for key, val in table.pairs:
-    dos_qhash_int_qbytearray_insert(hash, key.cint, val.cstring)
+    result.add(key.cint, @(val.toOpenArrayByte(0, val.high())))
 
 method flags*(self: QAbstractItemModel, index: QModelIndex): QtItemFlag {.base.} =
   ## Return the item flags and the given index
@@ -98,7 +98,7 @@ proc createIndex*(self: QAbstractItemModel, row: int, column: int, data: pointer
 method index*(self: QAbstractItemModel, row: int, column: int, parent: QModelIndex): QModelIndex {.base.} =
   doAssert(false, "QAbstractItemModel::index is pure virtual")
 
-proc indexCallback(modelPtr: pointer, row: cint, column: cint, parent: DosQModelIndex, result: DosQModelIndex) {.cdecl, exportc.} =
+proc indexCallback(modelPtr: pointer, row: cint, column: cint, parent: DosQModelIndex, result: var DosQModelIndex) {.cdecl, exportc.} =
   debugMsg("QAbstractItemModel", "indexCallback")
   let model = cast[QAbstractItemModel](modelPtr)
   let index = model.index(row.int, column.int, newQModelIndex(parent, Ownership.Clone))
@@ -107,7 +107,7 @@ proc indexCallback(modelPtr: pointer, row: cint, column: cint, parent: DosQModel
 method parent*(self: QAbstractItemModel, child: QModelIndex): QModelIndex {.base.} =
   doAssert(false, "QAbstractItemModel::parent is pure virtual")
 
-proc parentCallback(modelPtr: pointer, child: DosQModelIndex, result: DosQModelIndex) {.cdecl, exportc.} =
+proc parentCallback(modelPtr: pointer, child: DosQModelIndex, result: var DosQModelIndex) {.cdecl, exportc.} =
   debugMsg("QAbstractItemModel", "parentCallback")
   let model = cast[QAbstractItemModel](modelPtr)
   let index = model.parent(newQModelIndex(child, Ownership.Clone))

--- a/src/nimqml/private/qmetaobject.nim
+++ b/src/nimqml/private/qmetaobject.nim
@@ -11,18 +11,19 @@ proc setup(superClass: QMetaObject,
            signals: seq[SignalDefinition],
            slots: seq[SlotDefinition],
            properties: seq[PropertyDefinition]): DosQMetaObject =
-  var dosParameters: seq[seq[DosParameterDefinition]] = @[]
-  for i in 0..<signals.len:
-    var parameters: seq[DosParameterDefinition] = @[]
-    for p in signals[i].parameters:
-      parameters.add(DosParameterDefinition(name: p.name.cstring, metaType: p.metaType.cint))
-    dosParameters.add(parameters)
+  var dosParameters = newSeq[seq[DosParameterDefinition]](signals.len + slots.len)
+  # prevent garbage collector from reclaiming parameter defs in case `dosParameters`
+  # goes out of scope in the C code and thus gets reused for another stack var
+  when compiles(GC_ref(dosParameters)):
+    GC_ref(dosParameters)
 
   var dosSignals: seq[DosSignalDefinition] = @[]
   for i in 0..<signals.len:
-    let parametersCount = dosParameters[i].len.cint
     let name = signals[i].name.cstring
-    let dosSignal = DosSignalDefinition(name: name, parametersCount: parametersCount, parameters: if parametersCount > 0: dosParameters[i][0].unsafeAddr else: nil)
+    let parametersCount = signals[i].parameters.len.cint
+    for p in signals[i].parameters:
+      dosParameters[i].add(DosParameterDefinition(name: p.name.cstring, metaType: p.metaType.cint))
+    let dosSignal = DosSignalDefinition(name: name, parametersCount: parametersCount, parameters: if dosParameters[i].len > 0: dosParameters[i][0].unsafeAddr else: nil)
     dosSignals.add(dosSignal)
 
   var dosSlots: seq[DosSlotDefinition] = @[]
@@ -30,12 +31,10 @@ proc setup(superClass: QMetaObject,
     let name = slots[i].name.cstring
     let returnMetaType = slots[i].returnMetaType.cint
     let parametersCount = slots[i].parameters.len.cint
-    var parameters: seq[DosParameterDefinition] = @[]
     for p in slots[i].parameters:
-      parameters.add(DosParameterDefinition(name: p.name.cstring, metaType: p.metaType.cint))
+      dosParameters[i + signals.len].add(DosParameterDefinition(name: p.name.cstring, metaType: p.metaType.cint))
     let dosSlot = DosSlotDefinition(name: name, returnMetaType: returnMetaType,
-                                    parametersCount: parametersCount, parameters: if parameters.len > 0: parameters[0].unsafeAddr else: nil)
-    dosParameters.add(parameters)
+                                    parametersCount: parametersCount, parameters: if dosParameters[i + signals.len].len > 0: dosParameters[i + signals.len][0].unsafeAddr else: nil)
     dosSlots.add(dosSlot)
 
   var dosProperties: seq[DosPropertyDefinition] = @[]
@@ -54,7 +53,9 @@ proc setup(superClass: QMetaObject,
   let slots = DosSlotDefinitions(count: dosSlots.len.cint, definitions: if dosSlots.len > 0: dosSlots[0].unsafeAddr else: nil)
   let properties = DosPropertyDefinitions(count: dosProperties.len.cint, definitions: if dosProperties.len > 0: dosProperties[0].unsafeAddr else: nil)
 
-  return dos_qmetaobject_create(superClass.vptr, className.cstring, signals.unsafeAddr, slots.unsafeAddr, properties.unsafeAddr)
+  result = dos_qmetaobject_create(superClass.vptr, className.cstring, signals.unsafeAddr, slots.unsafeAddr, properties.unsafeAddr)
+  when compiles(GC_unref(dosParameters)):
+    GC_unref(dosParameters)
 
 proc invokeMethod*(typ: type QMetaObject, context: QObject, l: LambdaInvokerProc, connectionType: ConnectionType = ConnectionType.AutoConnection): bool =
   let id = LambdaInvoker.instance.add(l)

--- a/src/nimqml/private/qmodelindex.nim
+++ b/src/nimqml/private/qmodelindex.nim
@@ -8,7 +8,7 @@ proc setup(self: QModelIndex, other: DosQModelIndex, takeOwnership: Ownership) =
 
 proc delete*(self: QModelIndex) =
   ## Delete the given QModelIndex
-  if not self.vptr.isNil:
+  if self.vptr.isNil:
     return
   debugMsg("QModelIndex", "delete")
   dos_qmodelindex_delete(self.vptr)

--- a/src/nimqml/private/qvariant.nim
+++ b/src/nimqml/private/qvariant.nim
@@ -4,7 +4,11 @@ proc setup*(variant: QVariant) =
 
 proc setup*(variant: QVariant, value: int) =
   ## Setup a new QVariant given a cint value
-  variant.vptr = dos_qvariant_create_int(value.cint)
+  when sizeof(int) == sizeof(cint):
+    variant.vptr = dos_qvariant_create_int(value.cint)
+  else:
+    variant.vptr = dos_qvariant_create_int(value.clonglong)
+
 
 proc setup*(variant: QVariant, value: bool) =
   ## Setup a new QVariant given a bool value
@@ -83,9 +87,7 @@ proc `doubleVal=`*(variant: QVariant, value: cdouble) =
 
 proc stringVal*(variant: QVariant): string =
   ## Return the QVariant value as string
-  var rawCString = dos_qvariant_toString(variant.vptr)
-  result = $rawCString
-  dos_chararray_delete(rawCString)
+  variant.vPtr.toString()
 
 proc `stringVal=`*(variant: QVariant, value: string) =
   ## Sets the QVariant string value

--- a/src/nimside.nim
+++ b/src/nimside.nim
@@ -1,0 +1,347 @@
+import std/[macros, sequtils, strutils, tables], gen_qmetatype, gen_qobjectdefs
+
+from system/ansi_c import c_calloc, c_malloc, c_free
+
+const
+  AccessPrivate = cuint 0x00
+  AccessProtected = cuint 0x01
+  AccessPublic = cuint 0x02
+  AccessMask = cuint 0x03
+
+  MethodMethod = cuint 0x00
+  MethodSignal = cuint 0x04
+  MethodSlot = cuint 0x08
+  MethodConstructor = cuint 0x0c
+  MethodTypeMask = cuint 0x0c
+
+  MethodCompatibility = cuint 0x10
+  MethodCloned = cuint 0x20
+  MethodScriptable = cuint 0x40
+  MethodRevisioned = cuint 0x80
+
+  # PropertyFlags
+  Invalid = cuint 0x00000000
+  Readable = cuint 0x00000001
+  Writable = cuint 0x00000002
+  Resettable = cuint 0x00000004
+  EnumOrFlag = cuint 0x00000008
+  StdCppSet = cuint 0x00000100
+  Constant = cuint 0x00000400
+  Final = cuint 0x00000800
+  Designable = cuint 0x00001000
+  ResolveDesignable = cuint 0x00002000
+  Scriptable = cuint 0x00004000
+  ResolveScriptable = cuint 0x00008000
+  Stored = cuint 0x00010000
+  ResolveStored = cuint 0x00020000
+  Editable = cuint 0x00040000
+  ResolveEditable = cuint 0x00080000
+  User = cuint 0x00100000
+  ResolveUser = cuint 0x00200000
+  Notify = cuint 0x00400000
+  Revisioned = cuint 0x00800000
+  Required = cuint 0x01000000
+
+  # QMetaObjectPrivate offsets (5.15)
+  revisionPos = 0
+  classNamePos = 1
+  classInfoCountPos = 2
+  classInfoDataPos = 3
+  methodCountPos = 4
+  methodDataPos = 5
+  propertyCountPos = 6
+  propertyDataPos = 7
+  enumCountPos = 8
+  enumDataPos = 9
+  constructorCountPos = 10
+  constructorDataPos = 11
+  flagsPos = 12
+  signalCountPos = 13
+  QMetaObjectPrivateElems = 14
+
+  QMetaObjectRevision = 8
+    # 7 == 5.0
+    # 8 == 5.12
+
+type
+  QMetaObjectData = object
+    superdata: pointer
+    stringdata: pointer
+    data: ptr cuint
+    static_metacall: pointer
+    relatedMetaObjects: pointer
+    extradata: pointer
+
+  QByteArrayData = object
+    refcount: cint # atomic..
+    size: cuint
+    alloc: uint32 # bitfield...
+    offset: uint # ptrdiff_t
+
+  ParamDef* = object
+    name*: string
+    metaType*: cint
+
+  MethodDef* = object
+    name*: string
+    returnMetaType*: cint
+    params*: seq[ParamDef]
+    flags*: cuint
+
+  PropertyDef* = object
+    name*: string
+    metaType*: cint
+    readSlot*, writeSlot*, notifySignal*: string
+
+  QObjectDef* = object
+    name*: string
+    signals*: seq[MethodDef]
+    slots*: seq[MethodDef]
+    properties*: seq[PropertyDef]
+
+template usizeof(T): untyped =
+  cuint(sizeof(T))
+
+func isSignal*(m: MethodDef): bool =
+  (m.flags and MethodSignal) > 0
+func isSlot*(m: MethodDef): bool =
+  (m.flags and MethodSlot) > 0
+
+proc signalDef*(
+    _: type MethodDef, name: string, params: openArray[ParamDef]
+): MethodDef =
+  MethodDef(
+    name: name,
+    params: @params,
+    returnMetaType: QMetaTypeTypeEnum.Void,
+    flags: MethodSignal or AccessPublic,
+  )
+
+proc slotDef*(
+    _: type MethodDef, name: string, returnMetaType: cint, params: openArray[ParamDef]
+): MethodDef =
+  MethodDef(
+    name: name,
+    params: @params,
+    returnMetaType: returnMetaType,
+    flags: MethodSlot or AccessPublic,
+  )
+
+proc genMetaObjectData*(
+    className: string,
+    signals: openArray[MethodDef],
+    slots: openArray[MethodDef],
+    props: openArray[PropertyDef],
+): (seq[cuint], seq[byte]) =
+  # Class names need to be globally unique
+  # TODO use something other than a thread var
+  var counter {.threadvar.}: CountTable[string]
+
+  let c = counter.getOrDefault(className, 0)
+  counter.inc(className)
+
+  let
+    className = className & (if c > 0: $c else: "")
+    methods = @signals & @slots
+    methodCount = cuint(methods.len())
+    methodParamsSize = cuint(foldl(methods, a + b.params.len, 0)) * 2 + methodCount
+
+    hasNotifySignals = anyIt(props, it.notifySignal.len > 0)
+    metaSize =
+      QMetaObjectPrivateElems + methodCount * 5 + methodParamsSize + cuint(
+        props.len * 3
+      ) + cuint(ord(hasNotifySignals)) * cuint(props.len) + 1
+
+  var data = newSeq[cuint](metaSize.int)
+  data[revisionPos] = QMetaObjectRevision
+
+  var dataIndex = cuint QMetaObjectPrivateElems
+  var paramsIndex = cuint(0)
+
+  block: # classinfo
+    discard
+
+  block: # methods
+    data[methodCountPos] = methodCount
+    data[methodDataPos] = dataIndex
+    dataIndex += 5 * methodCount
+
+    paramsIndex = dataIndex
+    dataIndex += methodParamsSize
+
+    data[propertyCountPos] = cuint(props.len)
+    data[propertyDataPos] = dataIndex
+
+    dataIndex += 3 * data[propertyCountPos]
+    if hasNotifySignals:
+      dataIndex += data[propertyCountPos]
+
+    data[signalCountPos] = cuint signals.len
+
+  dataIndex = QMetaObjectPrivateElems
+
+  var
+    strings: OrderedTable[string, int]
+    indices: seq[QByteArrayData]
+    stringtmp: string
+
+  template addString(s: untyped): cuint =
+    let slen = strings.len()
+    let pos = strings.mgetOrPut($s, strings.len)
+    if strings.len > slen:
+      indices.add(QByteArrayData(refcount: -1, size: cuint(len(s))))
+
+      stringtmp.add s
+      stringtmp.add '\0'
+    pos.cuint
+
+  block:
+    discard addString(className)
+
+  block: # Methods and their parameters
+    for m in methods:
+      data[dataIndex] = addString(m.name)
+      data[dataIndex + 1] = cuint m.params.len
+      data[dataIndex + 2] = paramsIndex
+      data[dataIndex + 3] = addString("") # TODO tag
+      data[dataIndex + 4] = m.flags
+      dataIndex += 5
+      paramsIndex += 1 + cuint m.params.len * 2
+
+  block: # Return types
+    for m in methods:
+      # TODO moc does not allow return-by-reference, replacing it with void:
+      # https://github.com/openwebos/qt/blob/92fde5feca3d792dfd775348ca59127204ab4ac0/src/tools/moc/moc.cpp#L400
+      data[dataIndex] = cuint m.returnMetaType
+      dataIndex += 1
+      for p in m.params:
+        data[dataIndex] = cuint p.metaType # TODO builtin?
+        dataIndex += 1
+
+      for p in m.params:
+        data[dataIndex] = addString p.name # TODO builtin?
+        dataIndex += 1
+
+  block: # Properties
+    for p in props:
+      data[dataIndex] = addString(p.name)
+      data[dataIndex + 1] = cuint p.metaType
+      data[dataIndex + 2] = block:
+        var v = Scriptable or Designable or Stored or Editable
+        if p.readSlot.len > 0:
+          v = v or Readable
+        if p.writeSlot.len > 0:
+          v = v or Writable
+        if p.notifySignal.len > 0:
+          v = v or Notify
+        if p.writeSlot.len == 0 and p.notifySignal.len == 0:
+          v = v or Constant
+        v
+
+      dataIndex += 3
+
+  if hasNotifySignals:
+    for p in props:
+      if p.notifySignal.len > 0:
+        var x = cuint 0
+        for m in methods.filterIt(it.isSignal):
+          if m.name == p.notifySignal:
+            break
+          x += 1
+        data[dataIndex] = x
+      else:
+        data[dataIndex] = 0
+      dataIndex += 1
+
+  dataIndex += 1
+
+  var offset = cuint(sizeof(QByteArrayData) * strings.len)
+  for i in 0 ..< indices.len:
+    indices[i].offset = offset
+    offset -= usizeof(QByteArrayData)
+    offset += indices[i].size + 1
+
+  var
+    stringdata = newSeq[byte](strings.len * sizeof(QByteArrayData) + stringtmp.len)
+    pos = 0
+
+  for i in 0 ..< indices.len:
+    assert(sizeof(QByteArrayData) == 24)
+
+    proc toBytes(v: SomeInteger): array[sizeof(v), byte] =
+      # VM can't do casts :/
+      for i in 0 ..< sizeof(result):
+        result[i] = byte((v shr (i * 8)) and 0xff)
+
+    stringdata[pos ..< pos + 3] = toBytes(cast[cuint](indices[i].refcount))
+    pos += 4
+
+    stringdata[pos ..< pos + 3] = toBytes(cast[cuint](indices[i].size))
+    pos += 4
+
+    stringdata[pos ..< pos + 3] = toBytes(cast[cuint](indices[i].alloc))
+    pos += 4
+
+    pos += 4 # Alignment
+
+    stringdata[pos ..< pos + 7] = toBytes(cast[uint](indices[i].offset))
+    pos += 8
+
+  let pstrings = sizeof(QByteArrayData) * strings.len
+
+  for i, c in stringtmp:
+    stringdata[pstrings + i] = byte(stringtmp[i])
+
+  (data, stringdata)
+
+proc createMetaObject*(
+    superclassMetaObject: gen_qobjectdefs_types.QMetaObject,
+    data: openArray[cuint],
+    stringdata: seq[byte],
+): gen_qobjectdefs.QMetaObject =
+  let
+    superdata = superclassMetaObject.h
+    dataBytes = data.len * sizeof(cuint)
+    blob = cast[ptr UncheckedArray[byte]](c_malloc(csize_t(dataBytes + stringdata.len)))
+
+  copyMem(addr blob[0], addr data[0], dataBytes)
+  copyMem(addr blob[dataBytes], addr stringdata[0], stringdata.len())
+
+  var metaObjectData = QMetaObjectData(
+    superdata: superdata,
+    data: cast[ptr cuint](addr blob[0]),
+    stringdata: addr blob[dataBytes],
+  )
+
+  let tmp = gen_qobjectdefs.QMetaObject.create()
+  copyMem(tmp.h, addr metaObjectData, sizeof(QMetaObjectData))
+  tmp
+
+proc genMetaObject*(
+    superclassMetaObject: gen_qobjectdefs_types.QMetaObject,
+    className: string,
+    signals, slots: openArray[MethodDef],
+    props: openArray[PropertyDef],
+): gen_qobjectdefs_types.QMetaObject =
+  let (data, stringdata) = genMetaObjectData(className, signals, slots, props)
+  createMetaObject(superclassMetaObject, data, stringdata)
+
+type QObject_connectSlot* = proc(args: pointer) {.gcsafe, raises: [].}
+
+proc miqt_exec_callback_QObject(slot: int, args: pointer) {.exportc.} =
+  let slot = cast[ptr QObject_connectSlot](slot)
+  slot[](args)
+
+proc miqt_exec_callback_QObject_release(slot: int) {.exportc.} =
+  let slot = cast[ref QObject_connectSlot](slot)
+  GC_unref(slot)
+
+proc QObject_connectRawSlot*(
+  sender: pointer,
+  signal: cstring,
+  receiver: pointer,
+  slot: int,
+  release: pointer,
+  typeX: cint,
+  senderMetaObject: pointer,
+): pointer {.importc.}


### PR DESCRIPTION
`DOtherSide` is a hand-made built C++ -> C wrapper that exposes a small subset of Qt.

With an approach like
https://github.com/arnetheduck/nim-miqt-poc/pull/1, the full qt api, including both qml and regular Qt, can be mapped to C allowing access to all of qt in a low-maintenance manner, simplifying upgrades as well.

At the same time, the way the poc is written, the C++->C wrappers are generated class by class and therefore don't need a separate compilation step to first compile `DOtherSide` to a library which then is linked to nimqml - instead `{.compile.}` takes care of compiling the correct minimal set of qt using the right flags from `pkg-config`. There is also no need to write "nim headers" like `dotherside.nim` that import the c code to nim since these trivially can be generated as well.

This PR contains a poc-quality compatibility layer for qml that instead of dotherside imports miqt-poc. It's a bit janky of course because of how miqt-poc itself is just an experiment, but it shows the approach more or less - a more complete approach would remove the `DosQ*`-style classes as well.

With this approach, it also becomes possible to share the same c backend between `nimqml` and `nimqt`, reducing the overall maintenance burden of bringing Qt to Nim - the C++->C mapping step can also potentially be shared between other languages (go/zig/etc) which further speaks for the approach (either from a high-level "share-notes" level or by actually using the same C bindings).

The PoC is enough to run the `helloworld` example assuming the import paths in `nim.cfg` are updated, and that
https://github.com/arnetheduck/nim-miqt-poc/pull/1 is used (there is no need to "build" miqt-poc or re-run the generator as the generated code is deterministically generated from qt)